### PR TITLE
Fix jazzy installation check and add some improvements

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -74,6 +74,31 @@ workflows:
         - copyright: Future Workshops 2019
         - umbrella_header: ./ObjcSimpleFramework/ObjcSimpleFramework.h
     - change-workdir:
+        title: Project with spacing on name
+        description: |-
+          Test creation of documentation for project with a spacing in the name
+        run_if: true
+        inputs:
+        - path: ../Project\ Title
+    - path::./:
+        title: Running Jazzy for project with special characters
+        description: ''
+        run_if: true
+        inputs:
+        - project_path: "./Project Title"
+        - language: swift
+        - author: Future Workshops
+        - sdk: iphone
+        - version: 1.0.0
+        - framework_root: "./Project Title"
+        - module: Project_Title__Development_
+        - scheme: Project Title (Development)
+        - acl: public
+        - output: ./docs
+        - readme: ../README.md
+        - title: Project Title
+        - copyright: Future Workshops 2019
+    - change-workdir:
         title: Switch to Swift framework path
         description: |-
           To test the Swift documentation creation, we change to that path

--- a/step.sh
+++ b/step.sh
@@ -88,6 +88,7 @@ function create_jazzy_config() {
 	echo "" > "$CONFIGPATH"
 
 	echo "author: $AUTHOR" >> "$CONFIGPATH"
+	echo "output: \"$output\"" >> "$CONFIGPATH"
 
 	if [[ "$language" == "objc" ]]; then
 		return 0
@@ -184,13 +185,11 @@ echo "Running: "
 
 echo "jazzy $BASE_COMMAND \
 	--config \"$CONFIG_PATH\" \
-	--author $author \
 	--sdk $DOC_SDK \
 	--module-version $version \
 	--framework-root $framework_root \
 	--module $module \
 	--min-acl $acl \
-	--output \"$output\" \
 	--title \"$TITLE\" \
 	--readme \"$readme\" \
 	--copyright \"$COPYRIGHT\""
@@ -199,13 +198,11 @@ set +x
 
 jazzy $BASE_COMMAND \
 	--config "$CONFIG_PATH" \
-	--author $author \
 	--sdk $DOC_SDK \
 	--module-version $version \
 	--framework-root $framework_root \
 	--module $module \
 	--min-acl $acl \
-	--output "$output" \
 	--title "$TITLE" \
 	--readme "$readme" \
 	--copyright "$COPYRIGHT"

--- a/step.sh
+++ b/step.sh
@@ -98,6 +98,11 @@ function create_jazzy_config() {
 	echo "    - \"$SCHEMENAME\"" >> "$CONFIG_PATH"
 }
 
+function exists()
+{
+  command -v "$1" >/dev/null 2>&1
+}
+
 #=======================================
 # Main
 #=======================================
@@ -149,10 +154,10 @@ else
 	create_jazzy_config "$CONFIG_PATH" "$scheme" "$language" "$author"
 fi
 
-JAZZY="$(which jazzy)"
-
-if [[ "$JAZZY" == "" || "$JAZY" == "jazzy not found" ]]; then
-	gem install jazzy
+if ! exists jazzy; then
+  echo 'Your system does not have jazzy'
+  echo 'Installing jazzy'
+  gem install jazzy
 fi
 
 if [[ "$sdk" == "mac" || "$sdk" == "none" ]]; then

--- a/step.sh
+++ b/step.sh
@@ -190,8 +190,12 @@ echo "jazzy $BASE_COMMAND \
 	--framework-root $framework_root \
 	--module $module \
 	--min-acl $acl \
-	--output $output \
-	$EXTRA_PARAMETERS"
+	--output \"$output\" \
+	--title \"$TITLE\" \
+	--readme \"$readme\" \
+	--copyright \"$COPYRIGHT\""
+
+set +x
 
 jazzy $BASE_COMMAND \
 	--config "$CONFIG_PATH" \
@@ -201,10 +205,12 @@ jazzy $BASE_COMMAND \
 	--framework-root $framework_root \
 	--module $module \
 	--min-acl $acl \
-	--output $output \
+	--output "$output" \
 	--title "$TITLE" \
 	--readme "$readme" \
 	--copyright "$COPYRIGHT"
+
+set -x
 
 if [[ ! -n "$jazzy_configuration" ]]; then
 	rm "$CONFIG_PATH"

--- a/step.sh
+++ b/step.sh
@@ -156,8 +156,8 @@ else
 fi
 
 if ! exists jazzy; then
-  echo 'Your system does not have jazzy'
-  echo 'Installing jazzy'
+  echo_info 'Your system does not have jazzy'
+  echo_info 'Installing jazzy'
   gem install jazzy
 fi
 

--- a/step.yml
+++ b/step.yml
@@ -66,7 +66,7 @@ inputs:
       summary: Path to the jazzy.yaml file used to configure the build. If none is provided, a new one may be created
       is_expand: true
       is_required: false
-  - project_path: .
+  - project_path: ./
     opts:
       title: Project path
       summary: Path in where the script will be run
@@ -105,7 +105,7 @@ inputs:
       description: ""
       is_expand: true
       is_required: true
-  - framework_root: .
+  - framework_root: ./
     opts:
       title: Root path of the Framework
       summary: Root path of where the Framework is
@@ -132,6 +132,7 @@ inputs:
   - output: ./docs
     opts:
       title: Output of the doc set
+      description: You can set this to $BITRISE_DEPLOY_DIR/Docs if you want to have the docs as artifacts
       summary: Path to where the generated files will be saved
       is_expand: true
       is_required: true

--- a/test/Project Title/Project Title.xcodeproj/project.pbxproj
+++ b/test/Project Title/Project Title.xcodeproj/project.pbxproj
@@ -1,0 +1,340 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		78B8ACFB2493805600E990B2 /* Project_Title.h in Headers */ = {isa = PBXBuildFile; fileRef = 78B8ACF92493805600E990B2 /* Project_Title.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		78B8AD022493808000E990B2 /* SimpleClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78B8AD012493808000E990B2 /* SimpleClass.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		78B8ACF62493805600E990B2 /* Project_Title__Development_.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Project_Title__Development_.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		78B8ACF92493805600E990B2 /* Project_Title.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Project_Title.h; sourceTree = "<group>"; };
+		78B8ACFA2493805600E990B2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		78B8AD012493808000E990B2 /* SimpleClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleClass.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		78B8ACF32493805600E990B2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		78B8ACEC2493805600E990B2 = {
+			isa = PBXGroup;
+			children = (
+				78B8ACF82493805600E990B2 /* Project Title */,
+				78B8ACF72493805600E990B2 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		78B8ACF72493805600E990B2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				78B8ACF62493805600E990B2 /* Project_Title__Development_.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		78B8ACF82493805600E990B2 /* Project Title */ = {
+			isa = PBXGroup;
+			children = (
+				78B8ACF92493805600E990B2 /* Project_Title.h */,
+				78B8ACFA2493805600E990B2 /* Info.plist */,
+				78B8AD012493808000E990B2 /* SimpleClass.swift */,
+			);
+			path = "Project Title";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		78B8ACF12493805600E990B2 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				78B8ACFB2493805600E990B2 /* Project_Title.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		78B8ACF52493805600E990B2 /* Project Title (Development) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 78B8ACFE2493805600E990B2 /* Build configuration list for PBXNativeTarget "Project Title (Development)" */;
+			buildPhases = (
+				78B8ACF12493805600E990B2 /* Headers */,
+				78B8ACF22493805600E990B2 /* Sources */,
+				78B8ACF32493805600E990B2 /* Frameworks */,
+				78B8ACF42493805600E990B2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Project Title (Development)";
+			productName = "Project Title";
+			productReference = 78B8ACF62493805600E990B2 /* Project_Title__Development_.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		78B8ACED2493805600E990B2 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1150;
+				LastUpgradeCheck = 1150;
+				ORGANIZATIONNAME = "Future Workshops";
+				TargetAttributes = {
+					78B8ACF52493805600E990B2 = {
+						CreatedOnToolsVersion = 11.5;
+						LastSwiftMigration = 1150;
+					};
+				};
+			};
+			buildConfigurationList = 78B8ACF02493805600E990B2 /* Build configuration list for PBXProject "Project Title" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 78B8ACEC2493805600E990B2;
+			productRefGroup = 78B8ACF72493805600E990B2 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				78B8ACF52493805600E990B2 /* Project Title (Development) */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		78B8ACF42493805600E990B2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		78B8ACF22493805600E990B2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				78B8AD022493808000E990B2 /* SimpleClass.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		78B8ACFC2493805600E990B2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		78B8ACFD2493805600E990B2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		78B8ACFF2493805600E990B2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = F94732585Z;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Project Title/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.futureworkshops.Project-Title";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		78B8AD002493805600E990B2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = F94732585Z;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Project Title/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.futureworkshops.Project-Title";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		78B8ACF02493805600E990B2 /* Build configuration list for PBXProject "Project Title" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				78B8ACFC2493805600E990B2 /* Debug */,
+				78B8ACFD2493805600E990B2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		78B8ACFE2493805600E990B2 /* Build configuration list for PBXNativeTarget "Project Title (Development)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				78B8ACFF2493805600E990B2 /* Debug */,
+				78B8AD002493805600E990B2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 78B8ACED2493805600E990B2 /* Project object */;
+}

--- a/test/Project Title/Project Title.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/test/Project Title/Project Title.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Project Title.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/test/Project Title/Project Title.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/test/Project Title/Project Title.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/test/Project Title/Project Title.xcodeproj/xcshareddata/xcschemes/Project Title (Development).xcscheme
+++ b/test/Project Title/Project Title.xcodeproj/xcshareddata/xcschemes/Project Title (Development).xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1150"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "78B8ACF52493805600E990B2"
+               BuildableName = "Project_Title.framework"
+               BlueprintName = "Project Title"
+               ReferencedContainer = "container:Project Title.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "78B8ACF52493805600E990B2"
+            BuildableName = "Project_Title.framework"
+            BlueprintName = "Project Title"
+            ReferencedContainer = "container:Project Title.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/test/Project Title/Project Title/Info.plist
+++ b/test/Project Title/Project Title/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2020 Future Workshops. All rights reserved.</string>
+</dict>
+</plist>

--- a/test/Project Title/Project Title/Project_Title.h
+++ b/test/Project Title/Project Title/Project_Title.h
@@ -1,0 +1,19 @@
+//
+//  Project_Title.h
+//  Project Title
+//
+//  Created by Igor Ferreira on 12/06/2020.
+//  Copyright © 2020 Future Workshops. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for Project_Title.
+FOUNDATION_EXPORT double Project_TitleVersionNumber;
+
+//! Project version string for Project_Title.
+FOUNDATION_EXPORT const unsigned char Project_TitleVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Project_Title/PublicHeader.h>
+
+

--- a/test/Project Title/Project Title/SimpleClass.swift
+++ b/test/Project Title/Project Title/SimpleClass.swift
@@ -1,0 +1,26 @@
+//
+//  SimpleClass.swift
+//  SampleSwiftFramework
+//
+//  Created by Igor Ferreira on 22/11/2019.
+//  Copyright © 2019 Future Workshops. All rights reserved.
+//
+
+import Foundation
+
+/// Simple class used to test documentation definition
+public struct SimpleClass {
+    /// ID definition of the class
+    public let id: String
+    
+    /// Simply return the value stored as id
+    func showId() -> String {
+        return self.id
+    }
+    
+    /// Returns a complete object, made as \(element)_\(self.id)
+    /// - Parameter element: String to be prepended
+    func compose(element: String) -> String {
+        return "\(element)_\(self.id)"
+    }
+}


### PR DESCRIPTION
### Abstract

This PR is a collection of fixes for issues raised by the #4, focusing on an improved check of gem installation, and adding some log improvements.

### Fix

- I cherry-picked a [fix made in one of the project forks](https://github.com/andrewmarmion/bitrise-step-create-apple-documentation/commit/ed22a9deb0a4c0d6571e3bc846b8dff43941c14e) that does a better check for gem install
- Moved output and author from the jazzy command line to jazzy configuration file
- Added a test case for projects with complex Target/Module naming
- Marked jazzy command as a debug output, so the test may present a better build message